### PR TITLE
Updated EPEL dependency requirement version to >= 0.0.3 instead of ==

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -2,7 +2,7 @@ name 'lboynton-rpmfusion'
 version '0.0.2'
 source 'https://github.com/lboynton/puppet-rpmfusion'
 author 'lboynton'
-dependency 'stahnma/epel', '0.0.3'
+dependency 'stahnma/epel', '>=0.0.3'
 summary "Sets up the RPM Fusion repo on Fedora/CentOS/RHEL"
 description "Sets up the RPM Fusion repo on Fedora/CentOS/RHEL"
 project_page 'https://github.com/lboynton/puppet-rpmfusion'

--- a/Modulefile
+++ b/Modulefile
@@ -2,7 +2,7 @@ name 'lboynton-rpmfusion'
 version '0.0.2'
 source 'https://github.com/lboynton/puppet-rpmfusion'
 author 'lboynton'
-dependency 'stahnma/epel', '>=0.0.3'
+dependency 'stahnma/epel', '>= 0.0.3'
 summary "Sets up the RPM Fusion repo on Fedora/CentOS/RHEL"
 description "Sets up the RPM Fusion repo on Fedora/CentOS/RHEL"
 project_page 'https://github.com/lboynton/puppet-rpmfusion'


### PR DESCRIPTION
Having a more recent version of the EPEL module installed causes and exception when using librarian-puppet to download modules.
