### PR TITLE
Substitute os_maj_release by operatingsystemmajrelease

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,7 +45,7 @@ class rpmfusion::params {
         $supported_gpg = ['',6]
         $type = 'el'
         if $rpmfusion::with_version == true {
-          $version = $::os_maj_version
+          $version = $::operatingsystemmajrelease
         } else {
           $version = ''
         }


### PR DESCRIPTION
operatingsystemmajrelease is the official substitution of the custom fact os_maj_release since Facter 1.7. 
These days there's no need to use the custom fact instead of the official one, I think, and it will cause the
manifest to fail if the custom fact is not there.
